### PR TITLE
Fixed atom feed url

### DIFF
--- a/taskcluster-feed.xml
+++ b/taskcluster-feed.xml
@@ -7,7 +7,7 @@ layout: none
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.baseurl | prepend: site.url }}</link>
-    <atom:link href="{{ "feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
+    <atom:link href="{{ "taskcluster-feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml" />
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>


### PR DESCRIPTION
This fixes the link of the feed in the Subscriptions box of http://planet.mozilla.org/taskcluster.

Thanks Wander!
